### PR TITLE
Initial versions of Jenkins Pipeline examples.

### DIFF
--- a/Jenkins/JenkinsPipeline/declarative-pipeline-java-maven-snyk-binary-full-example/Jenkinsfile
+++ b/Jenkins/JenkinsPipeline/declarative-pipeline-java-maven-snyk-binary-full-example/Jenkinsfile
@@ -1,0 +1,84 @@
+pipeline {
+    agent any
+
+    // Install the Jenkins tools you need for your project / environment
+    tools {
+        maven 'maven-3.6.0' // Refers to a global tool configuration for Maven called 'maven-3.6.0'
+    }
+
+    // Pull your Snyk token from a Jenkins encrypted credential
+    // (type "Secret text"... see https://jenkins.io/doc/book/using/using-credentials/#adding-new-global-credentials)
+    // and put it in temporary environment variable for the Snyk CLI to consume.
+    environment {
+        SNYK_TOKEN = credentials('SNYK_TOKEN')
+    }
+
+    stages {
+
+        stage('Initialize & Cleanup Workspace') {
+            steps {
+               echo 'Initialize & Cleanup Workspace'
+               sh 'ls -la'
+               sh 'rm -rf *'
+               sh 'rm -rf .git'
+               sh 'rm -rf .gitignore'
+               sh 'ls -la'
+            }
+        }
+
+        stage('Git Clone') {
+            steps {
+                git url: 'https://github.com/jeff-snyk-demo/testproject-java-maven.git'
+                sh 'ls -la'
+            }
+        }
+
+        stage('Test Build Requirements') {
+            steps {
+                sh 'java -version'
+                sh 'mvn -v'
+            }
+        }
+
+        // Not required if just install the Snyk CLI on your Agent
+        stage('Download Snyk CLI') {
+            steps {
+                sh '''
+                    latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep "Location" | sed s#.*tag/##g | tr -d "\r")
+                    echo "Latest Snyk CLI Version: ${latest_version}"
+
+                    snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-linux"
+                    echo "Download URL: ${snyk_cli_dl_linux}"
+
+                    curl -Lo ./snyk "${snyk_cli_dl_linux}"
+                    chmod +x snyk
+                    ls -la
+                    ./snyk -v
+                '''
+            }
+        }
+
+        stage('Build') {
+            steps {
+              sh 'mvn package'
+            }
+        }
+
+        // Run snyk test to check for vulnerabilities and fail the build if any are found
+        // Consider using --severity-threshold=<low|medium|high> for more granularity (see snyk help for more info).
+        stage('Snyk Test using Snyk CLI') {
+            steps {
+                sh './snyk test'
+            }
+        }
+
+        // Capture the dependency tree for ongoing monitoring in Snyk.
+        // This is typically done after deployment to some environment (ex staging, test, production, etc).
+        stage('Snyk Monitor using Snyk CLI') {
+            steps {
+                // Use your own Snyk Organization with --org=<your-org>
+                sh './snyk monitor --org=demo-applications'
+            }
+        }
+    }
+}

--- a/Jenkins/JenkinsPipeline/declarative-pipeline-snyk-cli-binary-download-latest/Jenkinsfile
+++ b/Jenkins/JenkinsPipeline/declarative-pipeline-snyk-cli-binary-download-latest/Jenkinsfile
@@ -1,0 +1,24 @@
+pipeline {
+    agent any
+
+    stages {
+
+        // Not required if you just install the Snyk CLI on your Agent
+        stage('Download Latest Snyk CLI') {
+            steps {
+                sh '''
+                    latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep "Location" | sed s#.*tag/##g | tr -d "\r")
+                    echo "Latest Snyk CLI Version: ${latest_version}"
+
+                    snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-linux"
+                    echo "Download URL: ${snyk_cli_dl_linux}"
+
+                    curl -Lo ./snyk "${snyk_cli_dl_linux}"
+                    chmod +x snyk
+                    ls -la
+                    ./snyk -v
+                '''
+            }
+        }
+    }
+}

--- a/Jenkins/JenkinsPipeline/scripted-pipeline-java-maven-snyk-binary-full-example/Jenkinsfile
+++ b/Jenkins/JenkinsPipeline/scripted-pipeline-java-maven-snyk-binary-full-example/Jenkinsfile
@@ -1,0 +1,66 @@
+node {
+
+    def mavenHome = tool 'maven-3.6.0' // Refers to a global tool configuration for Maven called 'maven-3.6.0'
+    env.PATH="${env.PATH}:$mavenHome/bin"
+
+    stage('Initialize & Cleanup Workspace') {
+       echo 'Initialize & Cleanup Workspace'
+       sh 'ls -la'
+       sh 'rm -rf *'
+       sh 'rm -rf .git'
+       sh 'rm -rf .gitignore'
+       sh 'ls -la'
+    }
+
+    stage('Git Clone') {
+        git url: 'https://github.com/jeff-snyk-demo/testproject-java-maven.git'
+        sh 'ls -la'
+    }
+
+    stage('Test Build Requirements') {
+        sh 'java -version'
+        sh 'mvn -v'
+    }
+
+    // Not required if you install the Snyk CLI on your Agent
+    stage('Download Latest Snyk CLI') {
+        latest_version = sh(script: 'curl -Is "https://github.com/snyk/snyk/releases/latest" | grep "Location" | sed s#.*tag/##g', returnStdout: true)
+        latest_version = latest_version.trim()
+        echo "Latest Snyk CLI Version: ${latest_version}"
+
+        snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-linux"
+        echo "Download URL: ${snyk_cli_dl_linux}"
+
+        sh """
+            curl -Lo ./snyk "${snyk_cli_dl_linux}"
+            chmod +x snyk
+            ls -la
+            ./snyk -v
+        """
+    }
+
+    // Authorize the Snyk CLI
+    withCredentials([string(credentialsId: 'SNYK_TOKEN', variable: 'SNYK_TOKEN_VAR')]) {
+        stage('Authorize Snyk CLI') {
+            sh './snyk auth ${SNYK_TOKEN_VAR}'
+        }
+    }
+
+    stage('Build') {
+        sh 'mvn package'
+    }
+
+    // Run snyk test to check for vulnerabilities and fail the build if any are found
+    // Consider using --severity-threshold=<low|medium|high> for more granularity (see snyk help for more info).
+    stage('Snyk Test using Snyk CLI') {
+        sh './snyk test'
+    }
+
+    // Capture the dependency tree for ongoing monitoring in Snyk.
+    // This is typically done after deployment to some environment (ex staging, test, production, etc).
+    stage('Snyk Monitor using Snyk CLI') {
+        // Use your own Snyk Organization with --org=<your-org>
+        sh './snyk monitor --org=demo-applications'
+    }
+
+}

--- a/Jenkins/JenkinsPipeline/scripted-pipeline-snyk-cli-binary-download-latest/Jenkinsfile
+++ b/Jenkins/JenkinsPipeline/scripted-pipeline-snyk-cli-binary-download-latest/Jenkinsfile
@@ -1,0 +1,19 @@
+node {
+
+    // Not required if you install the Snyk CLI on your Agent
+    stage('Download Latest Snyk CLI') {
+        latest_version = sh(script: 'curl -Is "https://github.com/snyk/snyk/releases/latest" | grep "Location" | sed s#.*tag/##g', returnStdout: true)
+        latest_version = latest_version.trim()
+        echo "Latest Snyk CLI Version: ${latest_version}"
+
+        snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-linux"
+        echo "Download URL: ${snyk_cli_dl_linux}"
+
+        sh """
+            curl -Lo ./snyk "${snyk_cli_dl_linux}"
+            chmod +x snyk
+            ls -la
+            ./snyk -v
+        """
+    }
+}


### PR DESCRIPTION
Initial versions of Jenkins Pipeline examples.

Four examples total: for each Declarative Pipeline and Scripted Pipeline:
 - minimal example just showing how to download latest Snyk CLI binary
 - full example showing how it might be used in a Java (with Maven) project
